### PR TITLE
added TF_VAR_zone_name, needed for kops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV TF_VAR_account_id="126450723953"
 ENV TF_VAR_namespace="cpco"
 ENV TF_VAR_stage="testing"
 ENV TF_VAR_domain_name="testing.cloudposse.co"
+ENV TF_VAR_zone_name="testing.cloudposse.co."
 
 # chamber KMS config
 ENV CHAMBER_KMS_KEY_ALIAS="alias/${TF_VAR_namespace}-${TF_VAR_stage}-chamber"


### PR DESCRIPTION
The Dockerfile already copies kops from terraform-root-modules, runs build-kops-manifest, and defines almost all required variables for kops launch. Only TF_VAR_zone_name, required by main.tf (kops_state_backend.parent_zone_name) is not available.

will also add documentation to cold start doc on how to provision k8s