### PR TITLE
Bump module versions. Add `eks` module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM cloudposse/terraform-root-modules:0.5.6 as terraform-root-modules
+FROM cloudposse/terraform-root-modules:0.5.7 as terraform-root-modules
 
-FROM cloudposse/helmfiles:0.4.0 as helmfiles
+FROM cloudposse/helmfiles:0.7.2 as helmfiles
 
-FROM cloudposse/geodesic:0.28.0
+FROM cloudposse/geodesic:0.32.8
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"
@@ -43,6 +43,8 @@ COPY --from=terraform-root-modules /aws/chamber/ /conf/chamber/
 COPY --from=terraform-root-modules /aws/cloudtrail/ /conf/cloudtrail/
 COPY --from=terraform-root-modules /aws/kops/ /conf/kops/
 COPY --from=terraform-root-modules /aws/kops-aws-platform/ /conf/kops-aws-platform/
+COPY --from=terraform-root-modules /aws/eks/ /conf/eks/
+COPY --from=terraform-root-modules /aws/eks-backing-services-peering/ /conf/eks-backing-services-peering/
 
 # Copy helmfiles
 COPY --from=helmfiles /helmfile.d/ /conf/helmfile.d/


### PR DESCRIPTION
## what

* Bump module versions
* Add `eks` module

## why
* New `geodesic` version has Kubernetes and kubectl `1.10`
* New `terraform-root-modules` version has the EKS module
* New `helmfiles` version fixes `fluentd` chart

## provision EKS cluster

```
Outputs:

config_map_aws_auth = # The EKS service does not provide a cluster-level API parameter or resource to automatically configure the underlying Kubernetes cluster to allow worker nodes to join the cluster via AWS IAM role authentication.
# This is a Kubernetes ConfigMap configuration for worker nodes to join the cluster
# https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#required-kubernetes-configuration-to-join-worker-nodes

apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
data:
  mapRoles: |
    - rolearn: arn:aws:iam::xxxxxxxxxxxxx:role/cpco-testing-eks-workers
      username: system:node:{{EC2PrivateDNSName}}
      groups:
        - system:bootstrappers
        - system:nodes

eks_cluster_arn = arn:aws:eks:us-west-2:xxxxxxxxxxxxx:cluster/cpco-testing-eks-cluster
eks_cluster_certificate_authority_data = xxxxxxxxxxxxx=
eks_cluster_endpoint = https://xxxxxxxxxxxxx.sk1.us-west-2.eks.amazonaws.com
eks_cluster_id = cpco-testing-eks-cluster
eks_cluster_security_group_arn = arn:aws:ec2:us-west-2:xxxxxxxxxxxxx:security-group/sg-xxxxxxxxxxxxx
eks_cluster_security_group_id = sg-xxxxxxxxxxxxx
eks_cluster_security_group_name = cpco-testing-eks-cluster
eks_cluster_version = 1.10

kubeconfig = apiVersion: v1
kind: Config
preferences: {}

clusters:
- cluster:
    server: https://xxxxxxxxxxxxx.sk1.us-west-2.eks.amazonaws.com
    certificate-authority-data: xxxxxxxxxxxxx=
  name: cpco-testing-eks-cluster

contexts:
- context:
    cluster: cpco-testing-eks-cluster
    user: cpco-testing-eks-cluster
  name: cpco-testing-eks-cluster

current-context: cpco-testing-eks-cluster

users:
- name: cpco-testing-eks-cluster
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      command: aws-iam-authenticator
      args:
        - "token"
        - "-i"
        - "cpco-testing-eks-cluster"

workers_autoscaling_group_arn = arn:aws:autoscaling:us-west-2:xxxxxxxxxxxxx:autoScalingGroup:f9c697c8-4d73-4645-85b7-90743c91fadb:autoScalingGroupName/cpco-testing-eks-20180926045735083000000008
workers_autoscaling_group_default_cooldown = 300
workers_autoscaling_group_desired_capacity = 2
workers_autoscaling_group_health_check_grace_period = 300
workers_autoscaling_group_health_check_type = EC2
workers_autoscaling_group_id = cpco-testing-eks-20180926045735083000000008
workers_autoscaling_group_max_size = 3
workers_autoscaling_group_min_size = 2
workers_autoscaling_group_name = cpco-testing-eks-20180926045735083000000008
workers_launch_template_arn = arn:aws:ec2:us-west-2:xxxxxxxxxxxxx:launch-template/lt-xxxxxxxxxxxxx
workers_launch_template_id = lt-xxxxxxxxxxxxx
workers_security_group_arn = arn:aws:ec2:us-west-2:xxxxxxxxxxxxx:security-group/sg-xxxxxxxxxxxxx
workers_security_group_id = sg-xxxxxxxxxxxxx
workers_security_group_name = cpco-testing-eks-workers

```

```
✓   eks ⨠  kubectl get nodes  --kubeconfig kubeconfig-cpco-testing-eks-cluster.yaml
NAME                                           STATUS   ROLES    AGE   VERSION
ip-172-30-133-246.us-west-2.compute.internal   Ready    <none>   26s   v1.10.3
ip-172-30-161-108.us-west-2.compute.internal   Ready    <none>   21s   v1.10.3
```

```
✓  eks ⨠  kubectl get pods --all-namespaces --kubeconfig kubeconfig-cpco-testing-eks-cluster.yaml
NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE
kube-system   aws-node-59z26             1/1     Running   1          1h
kube-system   aws-node-6nzhf             1/1     Running   1          1h
kube-system   kube-dns-7cc87d595-qhshm   3/3     Running   0          2d
kube-system   kube-proxy-2dx4f           1/1     Running   0          1h
kube-system   kube-proxy-jlpf5           1/1     Running   0          1h
```

