### PR TITLE
Bump test k8s to 1 10 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cloudposse/terraform-root-modules:0.5.7 as terraform-root-modules
 
 FROM cloudposse/helmfiles:0.7.2 as helmfiles
 
-FROM cloudposse/geodesic:0.32.8
+FROM cloudposse/geodesic:0.45.1
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudposse/terraform-root-modules:0.5.7 as terraform-root-modules
 
-FROM cloudposse/helmfiles:0.7.2 as helmfiles
+FROM cloudposse/helmfiles:0.8.6 as helmfiles
 
 FROM cloudposse/geodesic:0.45.1
 


### PR DESCRIPTION
## what

See individual commits for detail.

## notes

These changes have already been deployed to the testing.cloudposse.co cluster:

```
 ✓   (cpco-testing-admin) ~ ⨠  kubectl get nodes
NAME                                          STATUS   ROLES    AGE   VERSION
ip-172-20-35-17.us-west-2.compute.internal    Ready    master   1d    v1.10.11
ip-172-20-45-164.us-west-2.compute.internal   Ready    node     20h   v1.10.11
ip-172-20-72-229.us-west-2.compute.internal   Ready    node     19h   v1.10.11
ip-172-20-74-56.us-west-2.compute.internal    Ready    master   20h   v1.10.11
ip-172-20-97-141.us-west-2.compute.internal   Ready    master   20h   v1.10.11
```

```
 ✓   (cpco-testing-admin) ~ ⨠  helm list | grep kiam
kiam                               	1       	Tue Dec 11 19:02:01 2018	DEPLOYED	kiam-2.0.0-rc1              	3.0-rc1    	kube-system
```
