### PR TITLE
Support aws-iam-authenticator with kops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudposse/helmfiles:0.8.6 as helmfiles
 
-FROM cloudposse/geodesic:0.67.0
+FROM cloudposse/geodesic:0.71.0
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"
@@ -56,6 +56,7 @@ ENV KOPS_STATE_STORE="s3://${NAMESPACE}-${STAGE}-kops-state"
 ENV KOPS_STATE_STORE_REGION="us-west-2"
 ENV KOPS_AVAILABILITY_ZONES="us-west-2a,us-west-2b,us-west-2c"
 ENV KOPS_BASTION_PUBLIC_NAME="bastion"
+ENV KOPS_AWS_IAM_AUTHENTICATOR_ENABLED="true"
 ENV BASTION_MACHINE_TYPE="t2.medium"
 ENV MASTER_MACHINE_TYPE="t2.medium"
 ENV NODE_MACHINE_TYPE="t2.medium"

--- a/conf/kops-aws-platform/.envrc
+++ b/conf/kops-aws-platform/.envrc
@@ -1,5 +1,5 @@
 # Import the remote module
-export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/kops-aws-platform?ref=tags/0.35.1"
+export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/kops-aws-platform?ref=tags/0.46.0"
 export TF_CLI_PLAN_PARALLELISM=2
 
 use terraform

--- a/conf/kops-aws-platform/terraform.tfvars
+++ b/conf/kops-aws-platform/terraform.tfvars
@@ -1,2 +1,4 @@
 region="us-west-2"
 zone_name="testing.cloudposse.co"
+
+cluster_id = "us-west-2.testing.cloudposse.co"


### PR DESCRIPTION
## what

This enabled AWS IAM authenticator in testing.cloudposse.co

Note that this PR does not _enforce_ IAM authentication and we can still talk to the k8s API via regular `kubectl export kubecfg`

## why

So that we can use IAM roles for RBAC

## dependant PRs

https://github.com/cloudposse/terraform-root-modules/pull/111
https://github.com/cloudposse/geodesic/pull/376

## testing

Build `testing.cloudposse.co` (also using the above PRs)

```
 ✓   (cpco-testing-admin) ~ ⨠  kopsctl login
Wrote Kube cfg to /dev/shm/kubecfg...
```

kubecfg is templated as below:

```
 ✓   (cpco-testing-admin) ~ ⨠  cat /dev/shm/kubecfg
apiVersion: v1
kind: Config
preferences: {}

clusters:
- cluster:
    server: https://api.us-west-2.testing.cloudposse.co
    certificate-authority-data: <REDACTED>
  name: us-west-2.testing.cloudposse.co

contexts:
- context:
    cluster: us-west-2.testing.cloudposse.co
    user: us-west-2.testing.cloudposse.co
  name: us-west-2.testing.cloudposse.co

current-context: us-west-2.testing.cloudposse.co

users:
- name: us-west-2.testing.cloudposse.co
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      command: aws-iam-authenticator
      args:
      - token
      - -i
      - us-west-2.testing.cloudposse.co
```

test it works and we can auth against the k8s API:

```
 ✓   (cpco-testing-admin) ~ ⨠  kubectl get nodes
NAME                                           STATUS   ROLES    AGE   VERSION
ip-172-20-100-72.us-west-2.compute.internal    Ready    master   4h    v1.10.11
ip-172-20-111-167.us-west-2.compute.internal   Ready    node     22d   v1.10.11
ip-172-20-35-199.us-west-2.compute.internal    Ready    node     12d   v1.10.11
ip-172-20-41-111.us-west-2.compute.internal    Ready    master   4h    v1.10.11
ip-172-20-45-164.us-west-2.compute.internal    Ready    node     55d   v1.10.11
ip-172-20-92-206.us-west-2.compute.internal    Ready    node     6h    v1.10.11
ip-172-20-94-81.us-west-2.compute.internal     Ready    master   4h    v1.10.11
```