### PR TITLE
Dockerfile: use latest geodesic (cve-2019-5736)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudposse/helmfiles:0.8.6 as helmfiles
 
-FROM cloudposse/geodesic:0.73.0
+FROM cloudposse/geodesic:0.74.1
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudposse/helmfiles:0.8.6 as helmfiles
 
-FROM cloudposse/geodesic:0.71.0
+FROM cloudposse/geodesic:0.73.0
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"


### PR DESCRIPTION
## what

bump version of `geodesic` used

## why

avoid upstream CVE