### PR TITLE
we require the tag here else the pipeline will fail to initialize

### DIFF
--- a/codefresh/terraform/pipeline.yml
+++ b/codefresh/terraform/pipeline.yml
@@ -32,6 +32,7 @@ steps:
     description: Build geodesic cloud automation shell
     image_name: ${{CF_REPO_NAME}}
     dockerfile: Dockerfile
+    tag: ${{CF_SHORT_REVISION}}
 
   cancel:
     title: "Cancel Builds"


### PR DESCRIPTION
@osterman Ran into an issue where pipeline would fail to initialize due to the tag argument not being present in the build step.

Can you please review?  I used the SHORT SHA for the tag.