### PR TITLE
Update `atlantis`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV NODE_MIN_SIZE="4"
 COPY rootfs/ /
 
 # Install atlantis
-RUN curl -fsSL -o /usr/bin/atlantis https://github.com/cloudposse/atlantis/releases/download/0.5.2/atlantis_linux_amd64 && \
+RUN curl -fsSL -o /usr/bin/atlantis https://github.com/cloudposse/atlantis/releases/download/0.8.0/atlantis_linux_amd64 && \
     chmod 755 /usr/bin/atlantis
 
 WORKDIR /conf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV DOCKER_TAG="latest"
 # General
 ENV NAMESPACE="cpco"
 ENV STAGE="testing"
-ENV DOMAIN_NAME="testing.cloudposse.co"
 ENV ZONE_ID="Z3SO0TKDDQ0RGG"
 
 # Geodesic banner

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -2,65 +2,140 @@ version: 2
 
 projects:
 
-- name: "tfstate-backend"
-  workflow: "make"
-  dir: "conf/tfstate-backend"
-  workspace: "default"
-  terraform_version: "v0.11.10"
-  autoplan:
-    when_modified:
-      - "Makefile*"
-      - "*.tf"
-      - "*.tfvars"
-      - ".envrc"
-    enabled: true
-  apply_requirements:
-    - "approved"
+  - name: "account-dns"
+    workflow: "make"
+    dir: "conf/account-dns"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
 
-- name: "account-dns"
-  workflow: "make"
-  dir: "conf/account-dns"
-  workspace: "default"
-  terraform_version: "v0.11.10"
-  autoplan:
-    when_modified:
-      - "Makefile*"
-      - "*.tf"
-      - "*.tfvars"
-      - ".envrc"
-    enabled: true
-  apply_requirements:
-    - "approved"
+  - name: "acm"
+    workflow: "make"
+    dir: "conf/acm"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
 
-- name: "acm"
-  workflow: "make"
-  dir: "conf/acm"
-  workspace: "default"
-  terraform_version: "v0.11.10"
-  autoplan:
-    when_modified:
-      - "Makefile*"
-      - "*.tf"
-      - "*.tfvars"
-      - ".envrc"
-    enabled: true
-  apply_requirements:
-    - "approved"
+  - name: "backing-services"
+    workflow: "make"
+    dir: "conf/backing-services"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
 
-- name: "cloudtrail"
-  workflow: "make"
-  dir: "conf/cloudtrail"
-  workspace: "default"
-  terraform_version: "v0.11.10"
-  autoplan:
-    when_modified:
-      - "Makefile*"
-      - "*.tf"
-      - "*.tfvars"
-      - ".envrc"
-    enabled: true
-  apply_requirements:
-    - "approved"
+  - name: "chamber"
+    workflow: "make"
+    dir: "conf/chamber"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
+
+  - name: "cloudtrail"
+    workflow: "make"
+    dir: "conf/cloudtrail"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
+
+  - name: "example"
+    workflow: "make"
+    dir: "conf/example"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
+
+  - name: "kops"
+    workflow: "make"
+    dir: "conf/kops"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
+
+  - name: "kops-aws-platform"
+    workflow: "make"
+    dir: "conf/kops-aws-platform"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
+
+  - name: "tfstate-backend"
+    workflow: "make"
+    dir: "conf/tfstate-backend"
+    workspace: "default"
+    terraform_version: "v0.11.10"
+    autoplan:
+      when_modified:
+        - "Makefile*"
+        - "*.tf"
+        - "*.tfvars"
+        - ".envrc"
+      enabled: true
+    apply_requirements:
+      - "approved"
 
 workflows:
   make:

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -2,7 +2,6 @@
 **/.terraform/*
 *.tfstate
 *.tfstate.*
-*.tfvars
 
 # Module directory
 .terraform

--- a/conf/ecs/.envrc
+++ b/conf/ecs/.envrc
@@ -1,7 +1,4 @@
-# Import the remote module
-export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/ecs?ref=tags/0.40.0"
-export TF_CLI_PLAN_PARALLELISM=2
-
+use envrc
 use terraform 0.11
 use atlantis
 use tfenv

--- a/conf/ecs/Makefile.tasks
+++ b/conf/ecs/Makefile.tasks
@@ -9,4 +9,6 @@ reset:
 ## Coldstart setup
 coldstart:
 	terraform apply -target module.dns
+	terraform apply -target module.acm
+	terraform apply -target module.alb
 	terraform apply

--- a/conf/ecs/Makefile.tasks
+++ b/conf/ecs/Makefile.tasks
@@ -9,6 +9,5 @@ reset:
 ## Coldstart setup
 coldstart:
 	terraform apply -target module.dns
-	terraform apply -target module.acm
-	terraform apply -target module.alb
+	terraform apply -target module.acm_request_certificate
 	terraform apply

--- a/conf/ecs/atlantis-repo-config.yaml
+++ b/conf/ecs/atlantis-repo-config.yaml
@@ -1,0 +1,22 @@
+# https://www.runatlantis.io/docs/configuring-atlantis.html
+# https://www.runatlantis.io/docs/server-configuration.html
+# https://www.runatlantis.io/docs/server-side-repo-config.html
+# https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html
+
+# repos lists the config for specific repos
+repos:
+  # id can either be an exact repo ID or a regex.
+  # If using a regex, it must start and end with a slash
+  # Repo ID's are of the form {VCS hostname}/{org}/{repo name}
+  - id: github.com/cloudposse/testing.cloudposse.co
+
+    # apply_requirements sets the Apply Requirements for all repos that match
+    apply_requirements: [approved]
+
+    # allowed_overrides specifies which keys can be overridden by this repo in
+    # its atlantis.yaml file
+    allowed_overrides: [apply_requirements, workflow]
+
+    # allow_custom_workflows defines whether this repo can define its own
+    # workflows. If false (default), the repo can only use server-side defined workflows
+    allow_custom_workflows: true

--- a/conf/ecs/atlantis.auto.tfvars
+++ b/conf/ecs/atlantis.auto.tfvars
@@ -20,8 +20,6 @@ atlantis_repo_owner = "cloudposse"
 
 atlantis_repo_whitelist = ["github.com/cloudposse/testing.cloudposse.co"]
 
-atlantis_allow_repo_config = "true"
-
 atlantis_repo_config = "/conf/ecs/atlantis-repo-config.yaml"
 
 atlantis_gh_user = "cloudpossebot"

--- a/conf/ecs/atlantis.auto.tfvars
+++ b/conf/ecs/atlantis.auto.tfvars
@@ -1,3 +1,15 @@
+# Write the atlantis_gh_token to SSM parameter store:
+# chamber write atlantis atlantis_gh_token "....."
+
+# When using Cognito authentication (atlantis_authentication_type = COGNITO), write the following values to SSM parameter store:
+# chamber write atlantis atlantis_cognito_user_pool_arn "....."
+# chamber write atlantis atlantis_cognito_user_pool_client_id "....."
+# chamber write atlantis atlantis_cognito_user_pool_domain "....."
+
+# When using OIDC authentication (atlantis_authentication_type = OIDC), write the following values to SSM parameter store:
+# chamber write atlantis atlantis_oidc_client_id "....."
+# chamber write atlantis atlantis_oidc_client_secret "....."
+
 atlantis_enabled = "true"
 
 atlantis_branch = "master"
@@ -10,8 +22,36 @@ atlantis_repo_whitelist = ["github.com/cloudposse/testing.cloudposse.co"]
 
 atlantis_allow_repo_config = "true"
 
+atlantis_repo_config = "/conf/ecs/atlantis-repo-config.yaml"
+
 atlantis_gh_user = "cloudpossebot"
 
 atlantis_gh_team_whitelist = "cloudposse:*,engineering:*"
 
-atlantis_wake_word = "atlantis"
+atlantis_authentication_type = "OIDC"
+
+atlantis_oidc_issuer = "https://accounts.google.com"
+
+atlantis_oidc_authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+
+atlantis_oidc_token_endpoint = "https://oauth2.googleapis.com/token"
+
+atlantis_oidc_user_info_endpoint = "https://openidconnect.googleapis.com/v1/userinfo"
+
+atlantis_alb_ingress_unauthenticated_paths = ["/events"]
+
+atlantis_alb_ingress_listener_unauthenticated_priority = "50"
+
+atlantis_alb_ingress_authenticated_paths = ["/*"]
+
+atlantis_alb_ingress_listener_authenticated_priority = "100"
+
+region = "us-west-2"
+
+availability_zones = ["us-west-2a", "us-west-2b"]
+
+nat_gateway_enabled = "false"
+
+nat_instance_enabled = "true"
+
+nat_instance_type = "t3.micro"

--- a/conf/ecs/atlantis.auto.tfvars
+++ b/conf/ecs/atlantis.auto.tfvars
@@ -28,13 +28,9 @@ atlantis_gh_team_whitelist = "cloudposse:*,engineering:*"
 
 atlantis_authentication_type = ""
 
-atlantis_alb_ingress_unauthenticated_paths = ["/events"]
+atlantis_alb_ingress_unauthenticated_paths = ["/*"]
 
 atlantis_alb_ingress_listener_unauthenticated_priority = "50"
-
-atlantis_alb_ingress_authenticated_paths = ["/*"]
-
-atlantis_alb_ingress_listener_authenticated_priority = "100"
 
 region = "us-west-2"
 

--- a/conf/ecs/atlantis.auto.tfvars
+++ b/conf/ecs/atlantis.auto.tfvars
@@ -28,15 +28,7 @@ atlantis_gh_user = "cloudpossebot"
 
 atlantis_gh_team_whitelist = "cloudposse:*,engineering:*"
 
-atlantis_authentication_type = "OIDC"
-
-atlantis_oidc_issuer = "https://accounts.google.com"
-
-atlantis_oidc_authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
-
-atlantis_oidc_token_endpoint = "https://oauth2.googleapis.com/token"
-
-atlantis_oidc_user_info_endpoint = "https://openidconnect.googleapis.com/v1/userinfo"
+atlantis_authentication_type = ""
 
 atlantis_alb_ingress_unauthenticated_paths = ["/events"]
 

--- a/conf/ecs/terraform.envrc
+++ b/conf/ecs/terraform.envrc
@@ -1,0 +1,3 @@
+# Import the remote module
+export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/ecs?ref=tags/0.87.0"
+export TF_CLI_PLAN_PARALLELISM=2


### PR DESCRIPTION
## what
* Update `atlantis`
* Update VPC and subnets modules for `atlantis`

## why
* Use the latest `atlantis` server version `0.8.0`
* Allow users to choose between NAT Gateways or NAT Instances to be deployed into the public subnets to allow the servers in the private subnets to access the Internet
* In many cases, NAT Instances are cheaper than NAT Gateways, and for some use-cases (e.g. testing/demo infrastructure) are more appropriate to use (e.g. save on cost)

## references
* https://github.com/cloudposse/atlantis/releases/tag/0.8.0
* https://github.com/cloudposse/terraform-aws-dynamic-subnets/pull/51
* https://github.com/cloudposse/terraform-root-modules/pull/180

