### PR TITLE
Nuke EKS clusters

### DIFF
--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -176,12 +176,10 @@ presets:
       - type: "regex"
         value: "^cpco-.*"
       EKSNodegroups:
-      - property: "tag:Name"
-        type: "regex"
+      - type: "regex"
         value: "^cpco-.*"
       EKSFargateProfile:
-      - property: "tag:Name"
-        type: "regex"
+      - type: "regex"
         value: "^cpco-.*"
       ELBLoadBalancer:
       - property: "tag:Name"

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -13,6 +13,7 @@ resource-types:
   - IAMRole
   - S3Object
   - S3Bucket
+  - AutoScalingGroup
   - EC2Address 
   - ElasticBeanstalkApplication
   - ElasticBeanstalkEnvironment
@@ -29,11 +30,16 @@ resource-types:
   - EC2NetworkInterface
   - ECSService
   - ECSCluster
+  - EKSCluster
+  - EKSFargateProfile
+  - EKSNodegroups
   - ELBLoadBalancer
   - ELBv2
   - ELBv2TargetGroup
   - LambdaFunction
   - LambdaEventSourceMapping
+  - CloudformationStack
+  - RDSInstance
 
   # don't nuke IAM users
   excludes:
@@ -83,6 +89,19 @@ presets:
       - property: "tag:Name"
         type: "regex"
         value: "^$"
+      EC2Volume:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^$"
+      CloudformationStack:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^$"
+      RDSInstance:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^$"
+
 
   cpco:
     filters:
@@ -141,11 +160,26 @@ presets:
       - property: "tag:Name"
         type: "regex"
         value: "^cpco-.*"
+      AutoScalingGroup:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
       ECSService:
       - property: "tag:Name"
         type: "regex"
         value: "^cpco-.*"
       ECSCluster:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
+      EKSCluster:
+      - type: "regex"
+        value: "^cpco-.*"
+      EKSNodegroups:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
+      EKSFargateProfile:
       - property: "tag:Name"
         type: "regex"
         value: "^cpco-.*"
@@ -163,3 +197,11 @@ presets:
         value: "^cpco-.*"
       - type: "regex"
         value: ".*atlantis.*"
+      CloudformationStack:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
+      RDSInstance:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudposse/geodesic:0.123.1
+FROM cloudposse/geodesic:0.132.2
 
 ENV DOCKER_IMAGE="cloudposse/testing.cloudposse.co"
 ENV DOCKER_TAG="latest"
@@ -39,13 +39,7 @@ RUN apk add go
 
 # Install terraform 0.11 for backwards compatibility
 RUN apk add terraform_0.11@cloudposse
-RUN apk add terraform_0.12@cloudposse terraform@cloudposse==0.12.10-r0
-
-# Pin helm to 2.14.3 for stability
-RUN apk add helm@cloudposse==2.14.3-r0
-
-# Pin helmfile to 0.81.0 for stability
-RUN apk update && apk add helmfile@cloudposse==0.94.1-r0
+RUN apk add terraform_0.12@cloudposse terraform@cloudposse
 
 # Place configuration in 'conf/' directory
 COPY conf/ /conf/

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ run:
 	$(SCRIPT)
 
 nuke:
-	docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v $(CURDIR)/.github:/.github quay.io/rebuy/aws-nuke:v2.14.0 --config /.github/aws-nuke.yaml --force --no-dry-run
+	docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v $(CURDIR)/.github:/.github quay.io/rebuy/aws-nuke:v2.15.0-beta.1 --config /.github/aws-nuke.yaml --force --no-dry-run
 
 nuke-dryrun:
-	docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v $(CURDIR)/.github:/.github quay.io/rebuy/aws-nuke:v2.14.0 --config /.github/aws-nuke.yaml --force
+	docker run -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -v $(CURDIR)/.github:/.github quay.io/rebuy/aws-nuke:v2.15.0-beta.1 --config /.github/aws-nuke.yaml --force --force-sleep=3


### PR DESCRIPTION
## what
* Update`aws-nuke` to 2.15.0-beta.1 which has support for EKS node pools
* Nuke EKS clusters

## why
* Clean up orphaned clusters from tests