### PR TITLE
terraform-config-inspect binary moved to where it could be found by PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN apk add go
 
 ## Install terraform-config-inspect (required for bats tests)
 ENV GO111MODULE="on"
-RUN go get github.com/hashicorp/terraform-config-inspect
+RUN go get github.com/hashicorp/terraform-config-inspect && \
+    mv $(go env GOPATH)/bin/terraform-config-inspect /usr/local/bin/
 
 # Install terraform 0.11 for backwards compatibility
 RUN apk add terraform@cloudposse \


### PR DESCRIPTION
## what
* terraform-config-inspect binary moved to where it could be found by PATH

## why
* to avoid issues with changed GOPATH if lookup for binary by Go module path

