### PR TITLE
Update Geodesic, restore some old support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ push:
 
 ## Install wrapper script from geodesic container
 install:
-	@docker run --rm $(DOCKER_IMAGE_NAME) | sudo -E bash -s $(DOCKER_TAG)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || \
+	  echo '"make install" failed, try "sudo make instal"' >&2
 
 ## Start the geodesic shell by calling wrapper script
 run:


### PR DESCRIPTION
## what
- Update Geodesic to 0.141.1
- Restore AWS_VAULT default support
- Restore support for Makefile-based Terraform
- Restore default `direnv` enabled

## why
- This repo still uses these features, but they were phased out as defaults in Geodesic 0.138.0