### PR TITLE
Tune aws-nuke: skip S3Objects, include RedShift

### DIFF
--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -5,7 +5,7 @@ regions:
   #- us-west-1
   #- us-west-2
 
-account-blacklist:
+account-blocklist:
   - "999999999999" # production
 
 resource-types:
@@ -17,7 +17,9 @@ resource-types:
     - IAMPolicy
     - IAMGroup
     - IAMGroupPolicyAttachment
-    - S3Object
+    # Deleting S3 Objects individually takes too long. We are either going to
+    # delete the entire S3 bucket or nothing in it, so we skip S3Object
+    # - S3Object
     - S3Bucket
     - AutoScalingGroup
     - EC2Address
@@ -39,7 +41,7 @@ resource-types:
     - ECSService
     - ECSCluster
     - EKSCluster
-    - EKSFargateProfile
+    - EKSFargateProfiles
     - EKSNodegroups
     - ELBLoadBalancer
     - ELBv2
@@ -53,7 +55,16 @@ resource-types:
     - Route53ResourceRecordSet
     - Route53HostedZone
     - ESDomain
-
+    - RedshiftCluster
+    - RedshiftParameterGroup
+    # You cannot delete automated Redshift Snapshots, and trying to delete
+    # them causes aws-nuke to exit with failure. Since we are not taking
+    # manual snapshots, we do not need to worry about them, but if we did,
+    # we should create a filter that leaves the automated snapshots alone.
+    # - RedshiftSnapshot
+    - RedshiftSubnetGroup
+  
+  
   # don't nuke IAM users
   excludes:
     - IAMUser

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -40,6 +40,7 @@ resource-types:
     - EC2KeyPair
     - ECSService
     - ECSCluster
+    - ECSTaskDefinition
     - EKSCluster
     - EKSFargateProfiles
     - EKSNodegroups
@@ -214,6 +215,10 @@ presets:
         - property: "tag:Name"
           type: "regex"
           value: "^cpco-.*"
+      ECSTaskDefinition:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
       EKSCluster:
         - type: "regex"
           value: "^cpco-.*"

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -63,7 +63,7 @@ resource-types:
     # we should create a filter that leaves the automated snapshots alone.
     # - RedshiftSnapshot
     - RedshiftSubnetGroup
-  
+    - IAMOpenIDConnectProvider
   
   # don't nuke IAM users
   excludes:
@@ -281,6 +281,10 @@ presets:
       IAMGroupPolicyAttachment:
         - type: "regex"
           value: "^cpco-.*"
+      IAMOpenIDConnectProvider:
+      - property: "tag:Name"
+        type: "regex"
+        value: "^cpco-.*"
       Route53ResourceRecordSet:
         - property: "Name"
           type: "exact"

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -18,7 +18,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: aws-nuke
-        uses: "docker://quay.io/rebuy/aws-nuke:v2.14.0"
+        uses: "docker://quay.io/rebuy/aws-nuke:v2.15.0"
         with:
           args: "--config .github/aws-nuke.yaml --force"
         env:
@@ -34,7 +34,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: aws-nuke
-        uses: "docker://quay.io/rebuy/aws-nuke:v2.14.0"
+        uses: "docker://quay.io/rebuy/aws-nuke:v2.15.0"
         with:
           args: "--config .github/aws-nuke.yaml --force --no-dry-run"
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,8 @@ on:
   release:
     types:
     - created
-  schedule:
-    - cron:  '0 0 * * *'
+  #  schedule:
+  #    - cron:  '0 0 * * *'
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=0.141.1
+ARG VERSION=0.146.4
 ARG OS=alpine
 FROM cloudposse/geodesic:$VERSION-$OS
 
@@ -44,12 +44,14 @@ ENV GO111MODULE="on"
 RUN go get github.com/hashicorp/terraform-config-inspect && \
     mv $(go env GOPATH)/bin/terraform-config-inspect /usr/local/bin/
 
-# Install terraform 0.11 for backwards compatibility
+# Install every "major" version of Terraform so we can use whichever one we want
 RUN apk add terraform@cloudposse      \
             terraform-0.11@cloudposse \
             terraform-0.12@cloudposse \
             terraform-0.13@cloudposse \
-            terraform-0.14@cloudposse
+            terraform-0.14@cloudposse \
+            terraform-0.15@cloudposse \
+            terraform-1@cloudposse
 
 # Use aws-vault for credentials
 ENV AWS_VAULT_ENABLED=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV AWS_DEFAULT_PROFILE="${NAMESPACE}-${STAGE}-admin"
 ENV AWS_MFA_PROFILE="${NAMESPACE}-root-admin"
 
 # Install go for running terratest
-RUN apk add go
+RUN apk add -uU go
 
 ## Install terraform-config-inspect (required for bats tests)
 ENV GO111MODULE="on"
@@ -45,13 +45,13 @@ RUN go get github.com/hashicorp/terraform-config-inspect && \
     mv $(go env GOPATH)/bin/terraform-config-inspect /usr/local/bin/
 
 # Install every "major" version of Terraform so we can use whichever one we want
-RUN apk add terraform@cloudposse      \
-            terraform-0.11@cloudposse \
-            terraform-0.12@cloudposse \
-            terraform-0.13@cloudposse \
-            terraform-0.14@cloudposse \
-            terraform-0.15@cloudposse \
-            terraform-1@cloudposse
+RUN apk add -uU terraform@cloudposse      \
+             terraform-0.11@cloudposse \
+             terraform-0.12@cloudposse \
+             terraform-0.13@cloudposse \
+             terraform-0.14@cloudposse \
+             terraform-0.15@cloudposse \
+             terraform-1@cloudposse
 
 # Use aws-vault for credentials
 ENV AWS_VAULT_ENABLED=true
@@ -63,7 +63,7 @@ ENV AWS_VAULT_ENABLED=true
 # https://github.com/99designs/aws-vault/issues/689
 # and until IMDSv2 is supported, aws-vault server does not work with kops 1.18
 # https://github.com/99designs/aws-vault/issues/690
-RUN apk add -u aws-vault@cloudposse~=4
+RUN apk add -uU aws-vault@cloudposse~=4
 
 # Filesystem entry for tfstate
 RUN s3 fstab '${TF_BUCKET}' '/' '/secrets/tf'


### PR DESCRIPTION
## what
- Tune aws-nuke: skip S3Objects, delete RedShift resources, ECS Task Definitions, and OIDC connectors
- Update Geodesic to current and install Terraform 0.15 and 1.x
- Disable nightly Docker builds

## why
- Action was timing out after 6 hours, probably because of the overhead of deleting S3 objects one at a time. Not necessary to delete S3 Objects because we will delete entire S3 Buckets which will cause S3 Objects to be deleted as well.
- We now have a tests that provision RedShift clusters and OIDC connectors, but we were not deleting them.
- Support current Terraform version as well as legacy version.
- Image is stable, does not change with nightly builds, and testing now uses `curl` to pull latest configuration anyway.