### PR TITLE
Update aws-nuke workflow

### DIFF
--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -1,6 +1,9 @@
 name: 'aws-nuke'
 
 on:
+  # Enable manual runs
+  workflow_dispatch:
+  
   # Enable pull request for testing
   pull_request: 
     types: [opened, synchronize, reopened]
@@ -13,10 +16,10 @@ jobs:
   # Run aws-nuke simulation (don't actually delete anything)
   dry-run:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: aws-nuke
         uses: "docker://quay.io/rebuy/aws-nuke:v2.15.0"
         with:
@@ -29,10 +32,10 @@ jobs:
   # Run aws-nuke "for reals" (delete everything)
   no-dry-run:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: aws-nuke
         uses: "docker://quay.io/rebuy/aws-nuke:v2.15.0"
         with:

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"      
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
 
   # Run aws-nuke "for reals" (delete everything)
   no-dry-run:
@@ -40,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
## what
- [aws-nuke workflow] update from obsolete `AWS_SECRET_KEY` to current `AWS_SECRET_ACCESS_KEY`
- [aws-nuke workflow] update `checkout` action to v2
- [aws-nuke workflow] add workflow dispatch for dry run

## why
- Some tools no longer work with `AWS_SECRET_KEY` as it has been deprecated for a long time
- Security improvements
- Enable status check of current environment

