### PR TITLE
Allow manual kickoff of aws-nuke

### DIFF
--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -3,20 +3,26 @@ name: 'aws-nuke'
 on:
   # Enable manual runs
   workflow_dispatch:
-  
+    inputs:
+      delete:
+        description: 'Set to "true" to actually delete stuff'
+        required: true
+        default: 'false'
+        
   # Enable pull request for testing
   pull_request: 
     types: [opened, synchronize, reopened]
 
   # Nuke testing account nightly
   schedule:
-    - cron:  '0 0 * * *'
+    # Run at noon UTC, 4 or 5am PT
+    - cron:  '0 12 * * *'
 
 jobs:
   # Run aws-nuke simulation (don't actually delete anything)
   dry-run:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || ( github.event_name == 'workflow_dispatch' && github.event.inputs.delete != 'true' )
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -32,7 +38,7 @@ jobs:
   # Run aws-nuke "for reals" (delete everything)
   no-dry-run:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && github.event.inputs.delete == 'true' )
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## what
- Allow manual kickoff of aws-nuke to delete resources
- Change scheduled nuke time to noon UTC, which is 4am PST and 5am PDT

## why
- Previous PR only allowed manual kickoff to see if resources needed to be deleted
- Previous scheduled nuke was during workday in US Pacific time zone, meaning a greater chance of nuking a test underway