### PR TITLE
Keep IAM Users and Organization Role

### DIFF
--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -32,9 +32,11 @@ regions:
   - us-gov-east-1
   - us-gov-west-1
 
+
+resource-types:
   # don't nuke IAM users
-excludes:
-  - IAMUser
+  excludes:
+    - IAMUser
 
 account-blocklist:
   - "999999999999" # production

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -32,9 +32,26 @@ regions:
   - us-gov-east-1
   - us-gov-west-1
 
+  # don't nuke IAM users
+excludes:
+  - IAMUser
+
 account-blocklist:
   - "999999999999" # production
 
 accounts:
   # testing account
-  126450723953: {}
+  126450723953:
+    presets:
+      - defaults
+
+presets:
+  defaults:
+    filters:
+      IAMRole:
+        - "OrganizationAccountAccessRole"
+
+      IAMRolePolicy:
+        - property: "role:RoleName"
+          type: "regex"
+          value: "^OrganizationAccountAccessRole$"

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -50,7 +50,6 @@ presets:
     filters:
       IAMRole:
         - "OrganizationAccountAccessRole"
-
       IAMRolePolicy:
         - property: "role:RoleName"
           type: "regex"

--- a/.github/aws-nuke.yaml
+++ b/.github/aws-nuke.yaml
@@ -35,6 +35,8 @@ regions:
   # don't nuke IAM users
 excludes:
   - IAMUser
+  - IAMUserAccessKey
+  - IAMUserPolicyAttachment
 
 account-blocklist:
   - "999999999999" # production


### PR DESCRIPTION
## what
* Keep IAM Users and Organization Role

## why
* AWS Nuke use IAM user so we need to have it until we cleanup all other resources
* Organization role required to access account from root account

## references
* DEV-389 deprecate-old-testing-org-and-iam-keys
